### PR TITLE
Make use of the resource bundle optional

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,12 @@
+# set to non-empty string to disable use of the resource bundle.
+#
+# e.g:
+#   just disableBundle=yes build
+disableBundle := ''
+
+# Flags used to configure the lake build
+lake_config_opts := if disableBundle == "" { "-K bundle=on" } else { "" }
+
 static_lib_path := join(justfile_directory(), "lib")
 raylib_src_path := join(justfile_directory(), "raylib-5.0", "src")
 extra_raylib_config_flags := ""
@@ -55,7 +64,7 @@ build_raylib:
 
 # build both the raylib library and the Lake project
 build: build_resvg build_raylib bundler
-    lake build
+    lake -R {{lake_config_opts}} build
 
 # clean only the Lake project
 clean:

--- a/justfile
+++ b/justfile
@@ -94,4 +94,4 @@ build-bundler:
 # run the bundler
 bundler: build-bundler
     mkdir -p {{parent_directory(bundle_h_path)}}
-    {{makebundle_output_path}} {{resource_dir}} {{bundle_h_path}}
+    {{makebundle_output_path}} {{justfile_directory()}} {{resource_dir}} {{bundle_h_path}}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,6 +1,8 @@
 import Lake
 open System Lake DSL
 
+def optionUseBundle : Bool := get_config? bundle == some "on"
+
 package «lean-raylib» where
   srcDir := "lean"
 
@@ -31,7 +33,10 @@ target raylib_bindings.o pkg : FilePath := do
   let raylibInclude := pkg.dir / "raylib-5.0" / "src"
   let resvgInclude := pkg.dir / "resvg-0.43.0" / "crates" / "c-api"
   let weakArgs := #["-I", s!"{raylibInclude}", "-I", s!"{includes}", "-I", s!"{resvgInclude}"]
-  buildLeanO oFile srcJob weakArgs #["-fPIC"]
+  let mut traceArgs := #["-fPIC"]
+  if not (optionUseBundle) then
+    traceArgs := traceArgs ++ #["-DRAYLEAN_NO_BUNDLE"]
+  buildLeanO oFile srcJob weakArgs traceArgs
 
 extern_lib libleanffi pkg := do
   let ffiO ← raylib_bindings.o.fetch

--- a/lean/Examples/Camera2DPlatformer.lean
+++ b/lean/Examples/Camera2DPlatformer.lean
@@ -120,7 +120,7 @@ def doRender : GameM Unit := do
 def main : IO Unit := do
   initWindow screenWidth screenHeight "2d camera"
   setTargetFPS fps
-  let walterTexture ← loadTextureFromImage (← loadImage "walter.png")
+  let walterTexture ← loadTextureFromImage (← loadImage "resources/walter.png")
   doRender
   |>.run' initGameState
   |>.run (initGameEnv walterTexture)

--- a/lean/Examples/Window.lean
+++ b/lean/Examples/Window.lean
@@ -6,7 +6,7 @@ def screenWidth : Nat := 800
 def screenHeight : Nat := 600
 
 def render : IO Unit := do
-  let texture ← loadTextureFromImage (← loadImage "Asset.svg")
+  let texture ← loadTextureFromImage (← loadImage "resources/Asset.svg")
   let sourceRect : Rectangle :=
     { x := 0
     , y := 0


### PR DESCRIPTION
The goal of this PR is to allow configuration of the project for `loadImage path` (and future APIs that load resources) to load resources from the filesystem instead of the resource `bundle.h`.

This is done in multiple steps.

1. The `makeBundle.lean` script now creates resources in `bundle.h` with path prefixed with `resource/`, i.e their relative paths in the repository. So now in the Window example the image is loaded using `loadImage "resources/Asset.svg"` instead of `loadImage "Asset.svg"`. 

2. A C-flag `RAYLEAN_NO_BUNDLE` is added so that raylib-binding.c can be configured to use the Raylib `LoadFileData` instead of loading data from the bundle. The `loadImage "resources/Asset.svg"` will continue to work when the example executable is run from the root of the project (i.e with `just run`).

3. A config option `bundle` is now used in the lakefile to configure if the bundle is used or not.

Builds using `just` will continue to use the resource bundle by default.

To disable use of the bundle in just use:

```
just disableBundle=y build
```

Projects that depend on the raylean library will have the bundle disabled by default. It can be enabled by setting the `bundle` configuration setting to on in the lakefile requires block:

```
require raylean from git "https://github.com/paulcadman/raylean" @ "main" with
  NameMap.empty
    |>.insert `bundle "on"
```

or via the CLI:

```
lake build -R -K bundle=on build
```