### PR TITLE
Support linux build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  build:
+  build-macos:
     runs-on: macos-latest
     steps:
       - uses: extractions/setup-just@v2
@@ -41,4 +41,37 @@ jobs:
         with:
           name: macos-aarch64-binary
           path: raylean_macos-aarch64.tar.gz
+          if-no-files-found: error
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: extractions/setup-just@v2
+
+      - name: Setup Rust
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Install raylib deps
+        run: sudo apt-get install -y --no-install-recommends libglfw3 libglfw3-dev libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxext-dev libxfixes-dev libwayland-dev libxkbcommon-dev
+
+      - name: install elan
+        run: |
+            set -o pipefail
+            curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+            ./elan-init -y --no-modify-path --default-toolchain none
+            echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - uses: actions/checkout@v4
+
+      - name: build project
+        run: just build
+
+      - name: create release tarball
+        run: |
+          tar zcf raylean_linux-x86_64.tar.gz -C .lake/build/bin raylean
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux_x86_64-binary
+          path: raylean_linux-x86_64.tar.gz.tar.gz
           if-no-files-found: error

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,5 +73,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: linux_x86_64-binary
-          path: raylean_linux-x86_64.tar.gz.tar.gz
+          path: raylean_linux-x86_64.tar.gz
           if-no-files-found: error

--- a/justfile
+++ b/justfile
@@ -27,6 +27,9 @@ raylib_config_flags := ""
 # Raylib CUSTOM_CFLAGS make parameter
 raylib_custom_cflags := raylib_config_flags + " " + raylib_os_custom_cflags
 
+# Raylib CC make paramter
+raylib_cc_parameter := if os() == "macos" { "/usr/bin/clang" } else { "gcc" }
+
 static_lib_path := join(justfile_directory(), "lib")
 raylib_src_path := join(justfile_directory(), "raylib-5.0", "src")
 resource_dir := join(justfile_directory(), "resources")
@@ -64,7 +67,7 @@ build_raylib:
     if [ ! -f "{{static_lib_path}}/libraylib.a" ]; then
         mkdir -p {{static_lib_path}}
         make -C {{raylib_src_path}} \
-            CC=/usr/bin/clang \
+            CC={{raylib_cc_parameter}} \
             PLATFORM=PLATFORM_DESKTOP \
             RAYLIB_LIBTYPE=STATIC \
             RAYLIB_RELEASE_PATH={{static_lib_path}} \

--- a/justfile
+++ b/justfile
@@ -7,9 +7,28 @@ disableBundle := ''
 # Flags used to configure the lake build
 lake_config_opts := if disableBundle == "" { "-K bundle=on" } else { "" }
 
+# Raylib CUSTOM_FLAGS tailed for the current os
+#
+# The macos differ from the raylib release workflow.
+# We require `-fno-objc-msgsend-selector-stubs` to be set.
+#
+# If this is not set then the clang 15 linker bundled with lean gives the
+# following error:
+#
+#   ld64.lld: error: undefined symbol: _objc_msgSend$update
+#
+# See https://stackoverflow.com/a/74054943
+#
+raylib_os_custom_cflags := if os() == "macos" { "-target arm64-apple-macos11 -DGL_SILENCE_DEPRECATION -fno-objc-msgsend-selector-stubs"  } else { "" }
+
+# Enable extra raylib configuration flags
+raylib_config_flags := ""
+
+# Raylib CUSTOM_CFLAGS make parameter
+raylib_custom_cflags := raylib_config_flags + " " + raylib_os_custom_cflags
+
 static_lib_path := join(justfile_directory(), "lib")
 raylib_src_path := join(justfile_directory(), "raylib-5.0", "src")
-extra_raylib_config_flags := ""
 resource_dir := join(justfile_directory(), "resources")
 bundle_h_path := join(justfile_directory(), "c", "include", "bundle.h")
 makebundle_src_path := join(justfile_directory(), "scripts", "makeBundle.lean")
@@ -44,22 +63,12 @@ build_raylib:
     set -euo pipefail
     if [ ! -f "{{static_lib_path}}/libraylib.a" ]; then
         mkdir -p {{static_lib_path}}
-        # This build differs from the raylib release workflow.
-        # We require `-fno-objc-msgsend-selector-stubs` to be set.
-        #
-        # If this is not set then the clang 15 linker bundled with lean gives the
-        # following error:
-        #
-        #   ld64.lld: error: undefined symbol: _objc_msgSend$update
-        #
-        # See https://stackoverflow.com/a/74054943
-        #
         make -C {{raylib_src_path}} \
             CC=/usr/bin/clang \
             PLATFORM=PLATFORM_DESKTOP \
             RAYLIB_LIBTYPE=STATIC \
             RAYLIB_RELEASE_PATH={{static_lib_path}} \
-            CUSTOM_CFLAGS="{{extra_raylib_config_flags}} -target arm64-apple-macos11 -DGL_SILENCE_DEPRECATION -fno-objc-msgsend-selector-stubs"
+            CUSTOM_CFLAGS="{{raylib_custom_cflags}}"
     fi
 
 # build both the raylib library and the Lake project

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -17,14 +17,16 @@ lean_lib «Lens»
 @[default_target]
 lean_exe «raylean» where
   root := `Main
-  moreLinkArgs :=
-    #[ "lib/libraylib.a"
-     , "lib/libresvg.a"
-     , "-isysroot", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
-     , "-framework", "IOKit"
-     , "-framework", "Cocoa"
-     , "-framework", "OpenGL"
-     ]
+  moreLinkArgs := Id.run do
+    let mut args := #[ "lib/libraylib.a" , "lib/libresvg.a"]
+    if (← System.Platform.isOSX) then
+      args := args ++
+        #[ "-isysroot", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+         , "-framework", "IOKit"
+         , "-framework", "Cocoa"
+         , "-framework", "OpenGL"
+         ]
+    args
 
 target raylib_bindings.o pkg : FilePath := do
   let oFile := pkg.buildDir / "c" / "raylib_bindings.o"


### PR DESCRIPTION
This PR parametrises:

1. The lakefile. The macOS specific framework and isysroot flags are set only when run on macOS platform
2. The Raylib build. I'm setting the compiler to GCC because that's what Raylib does in its [linux build](https://github.com/raysan5/raylib/blob/63ae57d2e31afa8bc8cab7f17f0e44afa4e7552d/.github/workflows/linux.yml#L80).

I've added a Github Action that builds the project on linux.

## Dependencies

To get the build working I installed:

```
sudo apt-get install -y --no-install-recommends libglfw3 libglfw3-dev libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxext-dev libxfixes-dev libwayland-dev libxkbcommon-dev
```

This is probably not minimal, is taken from the [raylib linux build workflow](https://github.com/raysan5/raylib/blob/63ae57d2e31afa8bc8cab7f17f0e44afa4e7552d/.github/workflows/linux.yml#L58).

## Testing

I've only tested that the project builds on linux. I only have headless linux so I can't run it.