### PR TITLE
Use `LEAN_CC=clang lake` for builds on linux.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,9 @@ jobs:
       - name: Setup Rust
         run: rustup toolchain install stable --profile minimal
 
+      - name: Install lean system dependencies
+        run: sudo apt-get install -y --no-install-recommends libc++-dev libgmp-dev libc++abi-dev
+
       - name: Install raylib deps
         run: sudo apt-get install -y --no-install-recommends libglfw3 libglfw3-dev libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxext-dev libxfixes-dev libwayland-dev libxkbcommon-dev
 

--- a/justfile
+++ b/justfile
@@ -30,6 +30,13 @@ raylib_custom_cflags := raylib_config_flags + " " + raylib_os_custom_cflags
 # Raylib CC make paramter
 raylib_cc_parameter := if os() == "macos" { "/usr/bin/clang" } else { "gcc" }
 
+# The command used to invoke lake
+#
+# LEAN_CC is used for linux because the example executable will fail to link if
+# raylib is built with a glibc that's incompatible with the one that's bundled
+# with leanc.
+lake_command := if os() == "linux" { "LEAN_CC=clang lake" } else { "lake" }
+
 static_lib_path := join(justfile_directory(), "lib")
 raylib_src_path := join(justfile_directory(), "raylib-5.0", "src")
 resource_dir := join(justfile_directory(), "resources")
@@ -76,11 +83,11 @@ build_raylib:
 
 # build both the raylib library and the Lake project
 build: build_resvg build_raylib bundler
-    lake -R {{lake_config_opts}} build
+    {{lake_command}} -R {{lake_config_opts}} build
 
 # clean only the Lake project
 clean:
-    lake clean
+    {{lake_command}} clean
 
 clean_static_lib:
     rm -rf {{static_lib_path}}


### PR DESCRIPTION
The LEAN_CC variable was introduced recently to use override the bundled clang (leanc) from the lean toolchain.

https://github.com/leanprover/lean4/pull/4477#issuecomment-2174623805

We must use LEAN_CC on linux because the example executable will fail to link if raylib is built with a glibc that's incompatible with the version that's bundled with leanc. This currently happens with the arch distro.

Thanks to @keeganperry7 for figuring this out.

In addition to installing clang we needed to install:

## Arch

libc++

## Debian / Ubuntu

libc++-dev, libgmp-dev, libc++abi-dev