### PR TITLE
Orbital: vary sideways velocity

### DIFF
--- a/lean/Raylean/Types.lean
+++ b/lean/Raylean/Types.lean
@@ -113,6 +113,7 @@ def right : Nat := 262
 def left : Nat := 263
 def down : Nat := 264
 def up : Nat := 265
+def r : Nat := 82
 
 end Key
 


### PR DESCRIPTION
You can now use the left and right arrow keys to change the sideways velocity of the 'selected' orbiting body.

Press `r` to reset the selected orbital body
Press `space` to reset the orbit trails.