### PR TITLE
ECS Add Sum component

### DIFF
--- a/lean/Examples/BouncingBall.lean
+++ b/lean/Examples/BouncingBall.lean
@@ -79,6 +79,12 @@ def deleteAt' (pos : Vector2) (radius : Float) : Position × Entity → System W
     (← checkCollisionPointRec pos {x := p.x - radius, y := p.y - radius, width := 2 * radius, height := 2 * radius : Rectangle})
     then destroy (Position × Velocity) e else return ()
 
+/-- An alternative to `deleteAt` that uses a Sum to delete an entry --/
+def deleteAt'' (pos : Vector2) (radius : Float) : Position → System World (Unit ⊕ Not Position)
+  | ⟨p⟩ => do if
+    (← checkCollisionPointRec pos {x := p.x - radius, y := p.y - radius, width := 2 * radius, height := 2 * radius : Rectangle})
+    then return .inr .Not else return .inl ()
+
 def update : System World Unit := do
   let c : Config ← get global
   if (← isMouseButtonPressed MouseButton.left) then


### PR DESCRIPTION
The `Sum` component allows cmap functions to set one of two alternatives.

The following function will delete the velocity component if the x component of the velocity is less than 5, otherwise will make no change.
```
f : Velocity -> Unit ⊕ Not Velocity
  | ⟨v⟩ => if v.x < 5
    then .inr .Not
    else .inl ()
```