### PR TITLE
ECS elab: Support Global and Unique storage in makeWorldAndComponents

### DIFF
--- a/lean/ECS/Elab.lean
+++ b/lean/ECS/Elab.lean
@@ -37,11 +37,31 @@ elab "makeMapComponent" elemIdent:ident : command => do
       constraint := rfl
   ))
 
+elab "makeGlobalComponent" elemIdent:ident : command => do
+  let elemName ← Lean.resolveGlobalConstNoOverload elemIdent
+  let axiomName : Ident ← liftCoreM (mkIdent <$> (mkFreshUserName (Name.mkSimple s!"Storage{elemIdent.getId}")))
+  elabCommand (← `(axiom $axiomName : StorageFam $(mkIdent elemName) = GlobalStorage $(mkIdent elemName)))
+  elabCommand (← `(instance : FamilyDef StorageFam $(mkIdent elemName) (GlobalStorage $(mkIdent elemName)) := ⟨$axiomName⟩))
+  elabCommand (← `(
+    instance : @Component $(mkIdent elemName) (GlobalStorage $(mkIdent elemName)) $(mkIdent elemName) _ _ where
+      constraint := rfl
+  ))
+
+elab "makeUniqueComponent" elemIdent:ident : command => do
+  let elemName ← Lean.resolveGlobalConstNoOverload elemIdent
+  let axiomName : Ident ← liftCoreM (mkIdent <$> (mkFreshUserName (Name.mkSimple s!"Storage{elemIdent.getId}")))
+  elabCommand (← `(axiom $axiomName : StorageFam $(mkIdent elemName) = UniqueStorage $(mkIdent elemName)))
+  elabCommand (← `(instance : FamilyDef StorageFam $(mkIdent elemName) (UniqueStorage $(mkIdent elemName)) := ⟨$axiomName⟩))
+  elabCommand (← `(
+    instance : @Component $(mkIdent elemName) (UniqueStorage $(mkIdent elemName)) $(mkIdent elemName) _ _ where
+      constraint := rfl
+  ))
+
 elab "makeMapComponents" elemIdents:ident* : command => do
   for t in (← elemIdents.mapM Lean.resolveGlobalConstNoOverload) do
     elabCommand (← `(makeMapComponent $(mkIdent t)))
 
-elab "makeWorldAndMapComponents" elemIdents:ident* : command => do
+elab "makeWorldAndComponents" "[" mapIdents:ident,* "]" "[" globalIdents:ident,* "]" "[" uniqueIdents:ident,* "]": command => do
   -- identifiers exposed to the caller
   let worldStructName := "World"
   let world := mkIdent <| Name.mkSimple worldStructName
@@ -49,18 +69,32 @@ elab "makeWorldAndMapComponents" elemIdents:ident* : command => do
   let worldmk := mkIdent <| Name.mkStr2 worldStructName "mk"
 
   -- resolve the type names of passed idenifiers
-  let elemNames := (← elemIdents.mapM Lean.resolveGlobalConstNoOverload)
+  let mapNames := (← mapIdents.elemsAndSeps.getSepElems.mapM Lean.resolveGlobalConstNoOverload)
+  let globalNames := (← globalIdents.elemsAndSeps.getSepElems.mapM Lean.resolveGlobalConstNoOverload)
+  let uniqueNames := (← uniqueIdents.elemsAndSeps.getSepElems.mapM Lean.resolveGlobalConstNoOverload)
 
   -- register all components
-  for t in elemNames do
+  for t in mapNames do
     elabCommand (← `(makeMapComponent $(mkIdent t)))
 
+  for t in globalNames do
+    elabCommand (← `(makeGlobalComponent $(mkIdent t)))
+
+  for t in uniqueNames do
+    elabCommand (← `(makeUniqueComponent $(mkIdent t)))
+
   -- fresh names for world fields
-  let worldNames ← mapMToSnd (const <| mkFreshIdent `world) elemNames
+  let worldMapNames ← mapMToSnd (const <| mkFreshIdent `world) mapNames
+  let worldGlobalNames ← mapMToSnd (const <| mkFreshIdent `world) globalNames
+  let worldUniqueNames ← mapMToSnd (const <| mkFreshIdent `world) uniqueNames
   let worldEntity ← mkFreshIdent `world
 
-  let mut fields ← worldNames.mapM <| fun (n, w) => do
+  let mut fields ← worldMapNames.mapM <| fun (n, w) => do
     `(Lean.Parser.Command.structExplicitBinder| ( $w : MapStorage $(mkIdent n) ))
+  fields := fields.append (← worldGlobalNames.mapM <| fun (n, w) => do
+    `(Lean.Parser.Command.structExplicitBinder| ( $w : GlobalStorage $(mkIdent n) )))
+  fields := fields.append (← worldUniqueNames.mapM <| fun (n, w) => do
+    `(Lean.Parser.Command.structExplicitBinder| ( $w : UniqueStorage $(mkIdent n) )))
   fields := fields.push (← `(Lean.Parser.Command.structExplicitBinder| ( $worldEntity : GlobalStorage EntityCounter )))
 
   -- define thw World structure
@@ -70,9 +104,19 @@ elab "makeWorldAndMapComponents" elemIdents:ident* : command => do
   ))
 
   -- register a Has instance for each component
-  for (t, w) in worldNames do
+  for (t, w) in worldMapNames do
     elabCommand (← `(
       instance : @Has $world $(mkIdent t) (MapStorage $(mkIdent t)) _ where
+        getStore := (·.$w) <$> read
+    ))
+  for (t, w) in worldGlobalNames do
+    elabCommand (← `(
+      instance : @Has $world $(mkIdent t) (GlobalStorage $(mkIdent t)) _ where
+        getStore := (·.$w) <$> read
+    ))
+  for (t, w) in worldUniqueNames do
+    elabCommand (← `(
+      instance : @Has $world $(mkIdent t) (UniqueStorage $(mkIdent t)) _ where
         getStore := (·.$w) <$> read
     ))
   elabCommand (← `(
@@ -81,18 +125,26 @@ elab "makeWorldAndMapComponents" elemIdents:ident* : command => do
   ))
 
   -- fresh names for World.mk constructure arguments
-  let storeNames ← mapMToSnd (const <| mkFreshIdent `store) elemNames
+  let mapStoreNames ← mapMToSnd (const <| mkFreshIdent `store) mapNames
+  let globalStoreNames ← mapMToSnd (const <| mkFreshIdent `store) globalNames
+  let uniqueStoreNames ← mapMToSnd (const <| mkFreshIdent `store) uniqueNames
   let storeEntity ← mkFreshIdent `store
 
   let mut storageInitLets := #[]
-  for (t, s) in storeNames do
+  for (t, s) in mapStoreNames do
     storageInitLets := storageInitLets.push
       (← `(Lean.Parser.Term.doSeqItem| let $s : MapStorage $(mkIdent t) ← ExplInit.explInit))
+  for (t, s) in globalStoreNames do
+    storageInitLets := storageInitLets.push
+      (← `(Lean.Parser.Term.doSeqItem| let $s : GlobalStorage $(mkIdent t) ← ExplInit.explInit))
+  for (t, s) in uniqueStoreNames do
+    storageInitLets := storageInitLets.push
+      (← `(Lean.Parser.Term.doSeqItem| let $s : UniqueStorage $(mkIdent t) ← ExplInit.explInit))
   storageInitLets := storageInitLets.push
     (← `(Lean.Parser.Term.doSeqItem| let $storeEntity : GlobalStorage EntityCounter ← ExplInit.explInit))
 
   let mut worldmkArgs := #[]
-  for (_, s) in storeNames do
+  for (_, s) in mapStoreNames ++ globalStoreNames ++ uniqueStoreNames do
     worldmkArgs := worldmkArgs.push s
   worldmkArgs := worldmkArgs.push storeEntity
 
@@ -102,3 +154,6 @@ elab "makeWorldAndMapComponents" elemIdents:ident* : command => do
       $storageInitLets:doSeqItem*
       return ($worldmk $worldmkArgs*)
 ))
+
+elab "makeWorldAndMapComponents" "[" elemIdents:ident,* "]": command => do
+  elabCommand (← `(makeWorldAndComponents [$elemIdents:ident,*] [] []))

--- a/lean/ECS/Elab.lean
+++ b/lean/ECS/Elab.lean
@@ -41,7 +41,7 @@ elab "makeMapComponents" elemIdents:ident* : command => do
   for t in (← elemIdents.mapM Lean.resolveGlobalConstNoOverload) do
     elabCommand (← `(makeMapComponent $(mkIdent t)))
 
-elab "makeWorldAndComponents" elemIdents:ident* : command => do
+elab "makeWorldAndMapComponents" elemIdents:ident* : command => do
   -- identifiers exposed to the caller
   let worldStructName := "World"
   let world := mkIdent <| Name.mkSimple worldStructName

--- a/lean/Examples/BasicECS.lean
+++ b/lean/Examples/BasicECS.lean
@@ -11,7 +11,7 @@ structure Camera where
   camera : Camera3D
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndComponents Camera
+makeWorldAndMapComponents Camera
 
 def init : System World Unit := do
   let mut camera : Camera3D := {

--- a/lean/Examples/BasicECS.lean
+++ b/lean/Examples/BasicECS.lean
@@ -11,7 +11,7 @@ structure Camera where
   camera : Camera3D
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndMapComponents Camera
+makeWorldAndMapComponents [Camera]
 
 def init : System World Unit := do
   let mut camera : Camera3D := {

--- a/lean/Examples/BouncingBall.lean
+++ b/lean/Examples/BouncingBall.lean
@@ -23,7 +23,7 @@ inductive Circle :=
   | Circle
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndComponents Position Velocity Config Circle
+makeWorldAndMapComponents Position Velocity Config Circle
 
 def init : System World Unit := do
   let screenWidth := 800

--- a/lean/Examples/BouncingBall.lean
+++ b/lean/Examples/BouncingBall.lean
@@ -18,12 +18,13 @@ structure Config where
   screenWidth : Float
   screenHeight : Float
   velocity : Vector2
+  deriving Inhabited
 
 inductive Circle :=
   | Circle
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndMapComponents [Position, Velocity, Config, Circle]
+makeWorldAndComponents [Position, Velocity, Circle] [Config] []
 
 def init : System World Unit := do
   let screenWidth := 800

--- a/lean/Examples/BouncingBall.lean
+++ b/lean/Examples/BouncingBall.lean
@@ -23,7 +23,7 @@ inductive Circle :=
   | Circle
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndMapComponents Position Velocity Config Circle
+makeWorldAndMapComponents [Position, Velocity, Config, Circle]
 
 def init : System World Unit := do
   let screenWidth := 800

--- a/lean/Examples/Orbital/Types.lean
+++ b/lean/Examples/Orbital/Types.lean
@@ -23,4 +23,4 @@ structure Selectable where
   selected : Bool
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndComponents Position Velocity OrbitPath Selectable Mass
+makeWorldAndMapComponents Position Velocity OrbitPath Selectable Mass

--- a/lean/Examples/Orbital/Types.lean
+++ b/lean/Examples/Orbital/Types.lean
@@ -19,8 +19,8 @@ structure OrbitPath where
 structure Mass where
   val : Float
 
-structure Selectable where
-  selected : Bool
+inductive Player where
+  | Player
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndMapComponents [Position, Velocity, OrbitPath, Selectable, Mass]
+makeWorldAndComponents [Position, Velocity, OrbitPath, Mass] [] [Player]

--- a/lean/Examples/Orbital/Types.lean
+++ b/lean/Examples/Orbital/Types.lean
@@ -23,4 +23,4 @@ structure Selectable where
   selected : Bool
 
 -- Brings `World` and `initWorld` into scope
-makeWorldAndMapComponents Position Velocity OrbitPath Selectable Mass
+makeWorldAndMapComponents [Position, Velocity, OrbitPath, Selectable, Mass]

--- a/lean/Raylean/Types.lean
+++ b/lean/Raylean/Types.lean
@@ -32,6 +32,9 @@ structure Camera2D where
   /-- Camera zoom (scaling), should be 1.0f by default -/
   zoom : Float
 
+instance : Inhabited Camera2D where
+  default := ⟨⟨0,0⟩, ⟨0,0⟩, 0, 1⟩
+
 inductive CameraProjection where
   | perspective
   | orthographic


### PR DESCRIPTION
###  ⚠️  ECS API change

The `makeWorldAndComponents` command is renamed to `makeWorldAndMapComponents` and now creates  components, storage and a `World` from a list of types.

### New ECS API

`makeWorldAndComponents` takes 3 lists of types. It creates components and a `World`. The kind of storage used differs between the 3 lists.

For example:
```
makeWorldAndComponents [Position, Velocity] [Config] [Player]
```

The first list associates `MapStorage` to each component - this is the standard storage. It implements all of the `Expl` instances.

The second list associates `GlobalStorage` to each component. This store holds a single value. It always returns `true` for `explExists` and ignores the `Entity` argument on `explGet` and `explSet`. It does not have instances for `ExplMembers` or `ExplDestroy`. All types in this list **must implement `Inhabited`**. This is used to initialise the storage. This can be used to store game config or other global parameters.

The third list associates `UniqueStorage` to each component. This store can store 0 or 1 value. This can use used to define (e.g) a`Player` component where there will only ever be one player.

I've updated the BouncingBall and Orbital examples to use the new `makeWorldAndComponents`.
