### PR TITLE
Add 2D Graphics library

### DIFF
--- a/c/raylib_bindings.c
+++ b/c/raylib_bindings.c
@@ -505,3 +505,14 @@ lean_obj_res drawLineV(lean_obj_arg startPos_arg, lean_obj_arg endPos_arg, lean_
   DrawLineV(startPos, endPos, color);
   return IO_UNIT;
 }
+
+lean_obj_res drawLineStrip(b_lean_obj_arg points_arg, lean_obj_arg color_arg) {
+  size_t pointCount = lean_array_size(points_arg);
+  Vector2* points = malloc(pointCount * sizeof(Vector2));
+  for (size_t i = 0; i < pointCount; i++) {
+    points[i] = vector2_of_arg(lean_array_get_core(points_arg, i));
+  }
+  DrawLineStrip(points, pointCount, color_of_arg(color_arg));
+  free(points);
+  return IO_UNIT;
+}

--- a/lean/ECS/System.lean
+++ b/lean/ECS/System.lean
@@ -143,3 +143,26 @@ def cmapM_
   for ety in sl do
     let x ← getX.explGet stx ety
     sys (compX.constraint.mp x)
+
+def cfold
+  [FamilyDef StorageFam cx sx]
+  [FamilyDef ElemFam sx tx]
+  [compX : @Component cx sx tx _ _]
+  [@Has w cx sx _]
+  [getX : @ExplGet sx tx _]
+  [mX : ExplMembers sx]
+  (f : a → cx → a) (accInit : a) : System w a := do
+  let stx ← Has.getStore cx
+  let sl ← mX.explMembers stx
+  sl.foldlM (fun a e => (f a ∘ compX.constraint.mp) <$> getX.explGet stx e) accInit
+
+/-- collect matching components into an array using the specified test/process function -/
+def collect
+  [FamilyDef StorageFam cx sx]
+  [FamilyDef ElemFam sx tx]
+  [@Component cx sx tx _ _]
+  [@Has w cx sx _]
+  [@ExplGet sx tx _]
+  [ExplMembers sx]
+  (f : cx → Option a) : System w (Array a) :=
+    cfold (fun acc e => f e |>.elim acc acc.push) #[]

--- a/lean/Examples/Camera2DPlatformer/Types.lean
+++ b/lean/Examples/Camera2DPlatformer/Types.lean
@@ -4,6 +4,7 @@ import Lens
 namespace Types
 
 open Raylean.Types
+open Lens
 
 structure Player where
   position : Vector2

--- a/lean/Examples/Window.lean
+++ b/lean/Examples/Window.lean
@@ -27,7 +27,8 @@ def render : IO Unit := do
   let rotation : Float := 0
   let rectangle := .rectangle 10 10 |> .color Color.red |> .scale ⟨20,20⟩
   let circle := (.circle 100 |> .color Color.blue |> .scale ⟨0.5, 0.5⟩)
-  let p := rectangle ++ circle |> .translate ⟨250, -50⟩ |> .scale ⟨1, 2⟩
+  let line :=  .line #[⟨100, 100⟩, ⟨200, 200⟩] |> .color Color.black
+  let p : Picture := line ++ (rectangle ++ circle |> .translate ⟨250, -50⟩ |> .scale ⟨1, 2⟩)
 
   while not (← windowShouldClose) do
     renderFrame do

--- a/lean/Examples/Window.lean
+++ b/lean/Examples/Window.lean
@@ -3,6 +3,7 @@ import «Raylean»
 namespace Window
 
 open Raylean.Types
+open Raylean.Graphics2D
 open Raylean
 
 def screenWidth : Nat := 800
@@ -24,9 +25,13 @@ def render : IO Unit := do
     }
   let origin : Vector2 := ⟨0, 0⟩
   let rotation : Float := 0
+  let rectangle := .rectangle 10 10 |> .color Color.red |> .scale ⟨20,20⟩
+  let circle := (.circle 100 |> .color Color.blue |> .scale ⟨0.5, 0.5⟩)
+  let p := rectangle ++ circle |> .translate ⟨250, -50⟩ |> .scale ⟨1, 2⟩
 
   while not (← windowShouldClose) do
     renderFrame do
+      renderPicture screenWidth.toFloat screenHeight.toFloat p
       clearBackground Color.Raylean.gold
       drawFPS 100 100
       let c := match (← IO.rand 0 6) with

--- a/lean/Lens/Basic.lean
+++ b/lean/Lens/Basic.lean
@@ -4,6 +4,8 @@ open Const
 def Lens (s t a b : Type) :=
   ∀ {f : Type → Type} [Functor f], (a → f b) → s → f t
 
+namespace Lens
+
 def view {s a : Type} (l : Lens s s a a) (x : s) : a :=
   (l (fun y => (y : Const a a)) x : Const a s)
 
@@ -15,7 +17,10 @@ def over {s t a b : Type} (l : Lens s t a b) (f : a → b) (x : s) : t :=
 
 infixl:50 " ^. " => flip view
 
+end Lens
+
 namespace Example
+open Lens
 
 structure Name where
   firstname : String
@@ -25,7 +30,7 @@ structure Person where
   name : Name
   age : Nat
 
-namespace Lens
+namespace Example.Lens
 
 def firstname : Lens Name Name String String :=
   fun {f} [Functor f] g p =>
@@ -35,9 +40,9 @@ def name : Lens Person Person Name Name :=
   fun {f} [Functor f] g p =>
     Functor.map (fun newName => { p with name := newName }) (g p.name)
 
-end Lens
+end Example.Lens
 
-open Lens
+open Example.Lens
 
 def exampleView : IO Unit :=
   let person : Person := { name := {firstname := "Alice", surname := "H"}, age := 30 }

--- a/lean/Lens/Elab.lean
+++ b/lean/Lens/Elab.lean
@@ -2,7 +2,7 @@ import Lens.Basic
 
 import Lean
 
-namespace Elab
+namespace Lens
 
 /-
 makeLenses T` creates a lens for each field of the structure `T`.
@@ -42,9 +42,11 @@ elab "makeLenses" structIdent:ident : command => do
     elabCommand d
   elabCommand (← `(end $lensNs))
 
-end Elab
+end Lens
 
 namespace Example
+
+open Lens
 
 structure P where
   name : Nat
@@ -76,7 +78,7 @@ def exampleView' : IO Unit :=
   IO.println s!"Name: {personName}"
 
 def exampleSet' : IO Unit :=
-  let person := { name := { firstname := "Alice", surname := "H"}, age := 30 }
+  let person : Person' := { name := { firstname := "Alice", surname := "H"}, age := 30 }
   let updatedPerson := set (name ∘ firstname) "Bob" person
   IO.println s!"Updated name: {updatedPerson.name.firstname}"
 

--- a/lean/Raylean.lean
+++ b/lean/Raylean.lean
@@ -2,3 +2,4 @@ import «Raylean».Core
 import «Raylean».Math
 import «Raylean».Types
 import «Raylean».Frame
+import «Raylean».Graphics2D

--- a/lean/Raylean/Core.lean
+++ b/lean/Raylean/Core.lean
@@ -85,6 +85,9 @@ opaque drawCircleV : (center : @& Vector2) → (radius : Float) → (color : @& 
 @[extern "drawLineV"]
 opaque drawLineV : (startPos : @& Vector2) → (endPos : @& Vector2) → (color : @& Color) → IO Unit
 
+@[extern "drawLineStrip"]
+opaque drawLineStrip : (points : @& Array Vector2) → (color : @& Color) → IO Unit
+
 @[extern "drawRectangleRec"]
 opaque drawRectangleRec : (rectangle : @& Rectangle) → (color : @& Color) → IO Unit
 

--- a/lean/Raylean/Graphics2D.lean
+++ b/lean/Raylean/Graphics2D.lean
@@ -1,0 +1,2 @@
+import Raylean.Graphics2D.Basic
+import Raylean.Graphics2D.Render

--- a/lean/Raylean/Graphics2D/Basic.lean
+++ b/lean/Raylean/Graphics2D/Basic.lean
@@ -9,13 +9,9 @@ inductive Picture : Type where
   | line (path : Array Vector2) : Picture
   | circle (radius : Float) : Picture
   | rectangle (width : Float) (height : Float)
-  | image : Image → Picture
-  | imageSelection (subsection : Rectangle) : Image → Picture
-  | text : String → Picture
   | color : Color → Picture → Picture
   | translate : Vector2 → Picture → Picture
   | scale : Vector2 → Picture → Picture
-  | rotate : Float → Picture → Picture
   | pictures : Array Picture → Picture
 
 instance : Inhabited Picture where

--- a/lean/Raylean/Graphics2D/Basic.lean
+++ b/lean/Raylean/Graphics2D/Basic.lean
@@ -1,0 +1,29 @@
+import Raylean.Types
+
+open Raylean.Types
+
+namespace Raylean.Graphics2D
+
+inductive Picture : Type where
+  | blank : Picture
+  | line (path : Array Vector2) : Picture
+  | circle (radius : Float) : Picture
+  | rectangle (width : Float) (height : Float)
+  | image : Image → Picture
+  | imageSelection (subsection : Rectangle) : Image → Picture
+  | text : String → Picture
+  | color : Color → Picture → Picture
+  | translate : Vector2 → Picture → Picture
+  | scale : Vector2 → Picture → Picture
+  | rotate : Float → Picture → Picture
+  | pictures : Array Picture → Picture
+
+instance : Inhabited Picture where
+  default := .blank
+
+instance : Append Picture where
+  append : Picture → Picture → Picture
+   | (.pictures ps1), (.pictures ps2) => .pictures <| ps1 ++ ps2
+   | (.pictures ps), p => .pictures <| ps.push p
+   | p, (.pictures ps) => .pictures <| #[p] ++ ps
+   | p1, p2 => .pictures #[p1, p2]

--- a/lean/Raylean/Graphics2D/Render.lean
+++ b/lean/Raylean/Graphics2D/Render.lean
@@ -51,10 +51,6 @@ partial def renderPicture' : (picture : Picture) → ReaderT RenderState IO Unit
   | .translate v p => renderPicture' p |>.local (over translate (·.add v))
   | .scale v p => renderPicture'  p |>.local (over scale (·.dot v))
   | .pictures ps => (fun _ => ()) <$> ps.mapM renderPicture'
-  | .rotate _ _ => return ()
-  | .text _ => return ()
-  | .image _ => return ()
-  | .imageSelection _ _ => return ()
 
 def renderPicture (width height : Float) (picture : Picture) : IO Unit :=
   let initState := {scale := ⟨1,1⟩, color := Color.transparent, translate := ⟨0,0⟩, center := ⟨width / 2, height / 2⟩}

--- a/lean/Raylean/Graphics2D/Render.lean
+++ b/lean/Raylean/Graphics2D/Render.lean
@@ -1,0 +1,61 @@
+import Raylean.Core
+import Raylean.Types
+import Raylean.Math
+import Raylean.Graphics2D.Basic
+import Lens
+import Raylean.Lean
+
+open Raylean.Types
+open Lens
+
+namespace Raylean.Graphics2D
+
+structure RenderState where
+  scale : Vector2
+  color : Color
+  translate : Vector2
+  center : Vector2
+
+def RenderState.doTranslate (s : RenderState) (v : Vector2) : Vector2 :=
+  ⟨v.x + s.translate.x, v.y - s.translate.y⟩
+
+def RenderState.toScreen (s : RenderState) (v : Vector2) : Vector2 :=
+  s.doTranslate ⟨s.center.x + s.scale.x * v.x, s.center.y - s.scale.y * v.y⟩
+
+makeLenses RenderState
+
+open RenderState.Lens
+
+def renderLine (points : Array Vector2) : ReaderT RenderState IO Unit :=
+  for (startPoint, endPoint) in points.zip (points.extract 1 points.size) do
+    let s ← read
+    drawLineV (s.toScreen startPoint) (s.toScreen endPoint) s.color
+
+def renderCircle (radius : Float) : ReaderT RenderState IO Unit := do
+  let s ← read
+  drawCircleV (s.doTranslate s.center) (radius * (max 0 (max s.scale.x s.scale.y))) s.color
+
+def renderRectangle (width height : Float) : ReaderT RenderState IO Unit := do
+  let s ← read
+  let topLeft : Vector2 := ⟨-width / 2, height / 2⟩
+  let p := s.toScreen topLeft
+  let r : Rectangle := {x := p.x, y := p.y, width := s.scale.x * width, height := s.scale.y * height}
+  drawRectangleRec r s.color
+
+partial def renderPicture' : (picture : Picture) → ReaderT RenderState IO Unit
+  | .blank => return ()
+  | .line ps => renderLine ps
+  | .circle radius => renderCircle radius
+  | .rectangle width height => renderRectangle width height
+  | .color c p  => renderPicture' p |>.local (set color c)
+  | .translate v p => renderPicture' p |>.local (over translate (·.add v))
+  | .scale v p => renderPicture'  p |>.local (over scale (·.dot v))
+  | .pictures ps => (fun _ => ()) <$> ps.mapM renderPicture'
+  | .rotate _ _ => return ()
+  | .text _ => return ()
+  | .image _ => return ()
+  | .imageSelection _ _ => return ()
+
+def renderPicture (width height : Float) (picture : Picture) : IO Unit :=
+  let initState := {scale := ⟨1,1⟩, color := Color.transparent, translate := ⟨0,0⟩, center := ⟨width / 2, height / 2⟩}
+  renderPicture' picture |>.run initState

--- a/lean/Raylean/Lean.lean
+++ b/lean/Raylean/Lean.lean
@@ -1,0 +1,3 @@
+
+/-- Execute a computation in a modified environment --/
+def ReaderT.local {ρ : Type u} (f : ρ → ρ) (r : ReaderT ρ m α) : ReaderT ρ m α := r.run ∘ f

--- a/lean/Raylean/Math.lean
+++ b/lean/Raylean/Math.lean
@@ -19,4 +19,6 @@ def sub (v1 : Vector2) (v2 : Vector2) : Vector2 :=
 def mul (v : Vector2) (s : Float) : Vector2 :=
   { x := s * v.x, y := s * v.y }
 
+def dot (v1 v2 : Vector2) : Vector2 := ⟨v1.x * v2.x, v1.y * v2.y⟩
+
 end Vector2


### PR DESCRIPTION
The goal of this PR is to provide a 2D Graphics library layer on top of raylib's API that's more uniform with respect to coordinates in a window and provides scaling and translation transformations on rectangles and circles and aggregations thereof.

The coordinate system for objects in the 2D Graphics library has its origin in the centre of the window instead of the top-left of the screen. And the y-axis values increase with increasing height.

See the Window and Orbital demos for examples of usage.

This PR also adds the `cfold` and `collect` ECS system functions that can be used to fold over / collect matching components respectively. The `collect` function is used in the Orbital demo.