### PR TITLE
graphics2d: scale now modifies a translation within a picture

### DIFF
--- a/lean/Examples/Orbital.lean
+++ b/lean/Examples/Orbital.lean
@@ -79,30 +79,27 @@ def update : System World Unit := do
   if (← isKeyDown Key.r) then cmap resetPlayer
   updateOrbitingBody (← getFrameTime)
 
-def translateScale (v : Vector2) : Vector2 :=
-  v.mul 100
-
-def bodyScale (mass : Mass) : Float := mass.val * 30
+def bodyScale (mass : Mass) : Float := mass.val * 0.3
 
 def staticBody (mass : Mass) (p : Position) : Picture :=
   .circle (bodyScale mass) |>
   .color .red |>
-  .translate (translateScale p.val)
+  .translate p.val
 
 def orbitingBody (p : Position) (c : Color) : Picture :=
-  .circle 10 |>
+  .circle 0.1 |>
   .color c |>
-  .translate (translateScale p.val)
+  .translate p.val
 
 def orbitPath (o : OrbitPath) : Picture :=
-  .line (o.val.map (translateScale ·)) |> .color .white
+  .line o.val |> .color .white
 
 def gamePicture : System World Picture := do
   let staticBodies ← collect (cx := Mass × Position × Not Velocity) <| fun (m, p, _) => staticBody m p |> some
   let playerOrbitingBody ← collect (cx := Player × Position × Velocity) <| fun (_, p, _) => orbitingBody p .green |> some
   let orbitingBodies ← collect (cx := Position × Velocity × Not Player) <| fun (p, _, _) => orbitingBody p .blue |> some
-  let orbitPaths ← collect <| fun o => orbitPath o |> some
-  return (.pictures (staticBodies ++ playerOrbitingBody ++ orbitingBodies ++ orbitPaths))
+  let orbitPaths ← collect <| some ∘ orbitPath
+  return (.scale ⟨100, 100⟩ <| .pictures (staticBodies ++ playerOrbitingBody ++ orbitingBodies ++ orbitPaths))
 
 def render : System World Unit :=
   renderFrame do

--- a/lean/Examples/Orbital.lean
+++ b/lean/Examples/Orbital.lean
@@ -46,7 +46,8 @@ def updateWithStatic (dt : Float) (staticBodies : Array (Mass × Position)) : Po
       -- p is the vector pointing from the oribiting body (po) to the static body (ps)
       let p := ps.sub po
       let pMag := p.length
-      let a := p |>.mul (m / pMag^3)
+      let softenedDistance := (pMag^2 + 0.25^2).sqrt
+      let a := p |>.mul (m / softenedDistance^3)
       vNew := vNew.add (a.mul dt)
     let pNew := po.add (vNew.mul dt)
     let oNew := o.push pNew

--- a/lean/Examples/Window.lean
+++ b/lean/Examples/Window.lean
@@ -26,9 +26,9 @@ def render : IO Unit := do
   let origin : Vector2 := ⟨0, 0⟩
   let rotation : Float := 0
   let rectangle := .rectangle 10 10 |> .color Color.red |> .scale ⟨20,20⟩
-  let circle := (.circle 100 |> .color Color.blue |> .scale ⟨0.5, 0.5⟩)
+  let circle := .circle 100 |> .color Color.blue |> .scale ⟨0.5, 0.5⟩
   let line :=  .line #[⟨100, 100⟩, ⟨200, 200⟩] |> .color Color.black
-  let p : Picture := line ++ (rectangle ++ circle |> .translate ⟨250, -50⟩ |> .scale ⟨1, 2⟩)
+  let p : Picture := line ++ (rectangle ++ circle |> .translate ⟨250, -40⟩ |> .scale ⟨1, 2⟩)
 
   while not (← windowShouldClose) do
     renderFrame do


### PR DESCRIPTION
The scale op now modifies a translation op within a picture.

NB translation and scaling are not commutative:

1. scaling a translated picture

```
    .circle r |> .translate t |> .scale s
```

results in a circle centered at `t.dot s`

2. translating a scaled picture

```
   .circle r |> .scale s |> translate t
```

results in a circle centered at `t`

The window and orbital examples are updated to demo this change.

This PR also adds a smoothing parameter to the orbit update function to prevent orbiting bodies flying to infinity.