### PR TITLE
Use the mathlib4 cache in CI build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: fetch mathlib cache
+        run: lake exe cache get
+
       - name: build project
         run: just build
 
@@ -62,6 +65,9 @@ jobs:
             echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
       - uses: actions/checkout@v4
+
+      - name: fetch mathlib cache
+        run: lake exe cache get
 
       - name: build project
         run: just build


### PR DESCRIPTION
The project build is now slower because we use mathllib4 in the project. This commit adds a command to the build workflow to fetch the cached build artefacts for mathlib (and other standard libraries).

This may speed up the CI build.